### PR TITLE
Add retry to git clone to shield jobs from Github temporary failure

### DIFF
--- a/roles/git/tasks/clone.yml
+++ b/roles/git/tasks/clone.yml
@@ -12,3 +12,7 @@
     repo: "{{ project_git_url }}"
     dest: "{{ project_root_folder }}"
     version: "{{ project_git_version | default(omit) }}"
+  register: git_clone_res
+  retries: 3
+  delay: 15
+  until: not git_clone_res.failed


### PR DESCRIPTION
@guidograzioli I thought the janus job failure of this morning was caused by Github not being available for a few instant, so I've added that to Janus (can't hurt).