### PR TITLE
Ignore errors when removing dir from downstream

### DIFF
--- a/roles/janus/tasks/remove_from_collection.yml
+++ b/roles/janus/tasks/remove_from_collection.yml
@@ -12,3 +12,4 @@
     git rm -rf {{ file_to_remove }}
   args:
     chdir: "{{ downstream_project }}"
+  ignore_errors: true


### PR DESCRIPTION
Not all collections will have a .github dir, don't fail when that is true.

A more robust long term solution would be to make `file_to_remove` as a user-provided var as some projects could have other files or directories beyond .github that need to be cleaned up, in the short term this change would help enable use of janus for collections like https://github.com/openshift/community.okd.