### PR TITLE
Avoid unnecessary depmap replacement attempts

### DIFF
--- a/roles/janus/defaults/main.yml
+++ b/roles/janus/defaults/main.yml
@@ -12,11 +12,11 @@ downstream_projects_dir: "{{ workdir }}/downstream"
 skip_setup: True
 post_processors_replacements: []
 upstream_downstream_collections_map:
-  - { upstream_name: 'redhat_csp_download', downstream_name: 'redhat_csp_download' }
-  - { upstream_name: 'jws', downstream_name: 'jws' }
-  - { upstream_name: 'wildfly', downstream_name: 'eap' }
-  - { upstream_name: 'infinispan', downstream_name: 'data_grid' }
-  - { upstream_name: 'keycloak', downstream_name: 'sso' }
-  - { upstream_name: 'amq', downstream_name: 'amq_broker' }
-  - { upstream_name: 'amq_streams', downstream_name: 'amq_streams' }
-  - { upstream_name: 'common', downstream_name: 'runtimes_common' }
+  - { upstream_name: 'middleware_automation.redhat_csp_download', downstream_name: 'redhat.redhat_csp_download' }
+  - { upstream_name: 'middleware_automation.jws', downstream_name: 'redhat.jws' }
+  - { upstream_name: 'middleware_automation.wildfly', downstream_name: 'redhat.eap' }
+  - { upstream_name: 'middleware_automation.infinispan', downstream_name: 'redhat.data_grid' }
+  - { upstream_name: 'middleware_automation.keycloak', downstream_name: 'redhat.sso' }
+  - { upstream_name: 'middleware_automation.amq', downstream_name: 'redhat.amq_broker' }
+  - { upstream_name: 'middleware_automation.amq_streams', downstream_name: 'redhat.amq_streams' }
+  - { upstream_name: 'middleware_automation.common', downstream_name: 'redhat.runtimes_common' }

--- a/roles/janus/tasks/collection_skeleton.yml
+++ b/roles/janus/tasks/collection_skeleton.yml
@@ -17,6 +17,15 @@
     src: "{{ project_root_folder }}/"
     dest: "{{ downstream_project }}"
 
+- name: "Load downstream dependencies from requirements.yml"
+  ansible.builtin.slurp:
+    src: "{{ downstream_project }}/requirements.yml"
+  register: used_deps
+
+- name: Intersect dependency map with declared dependencies
+  ansible.builtin.set_fact:
+    depmap: "{{ (depmap | default([])) + (used_deps['content'] | b64decode | from_yaml)['collections'] | map(attribute='name') }}"
+
 - name: Check if .github folders exist in {{ downstream_project }}."
   ansible.builtin.stat:
     path: "{{ downstream_project }}/.github"

--- a/roles/janus/tasks/roles/replace_deps_to_upstream_name_to_downstream.yml
+++ b/roles/janus/tasks/roles/replace_deps_to_upstream_name_to_downstream.yml
@@ -5,11 +5,12 @@
 
     - ansible.builtin.include_tasks: utils/rename_vars_in_file.yml
       vars:
-        upstream_value: "{{ upstream_namespace }}.{{ replacement.upstream_name }}"
-        downstream_value: "{{ downstream_namespace }}.{{ replacement.downstream_name }}"
+        upstream_value: "{{ replacement.upstream_name }}"
+        downstream_value: "{{ replacement.downstream_name }}"
       loop: "{{ upstream_downstream_collections_map }}"
       loop_control:
         loop_var: replacement
+      when: replacement.upstream_name in depmap
   rescue:
     - ansible.builtin.debug:
         msg: "File `{{ path_to_file }}` not found: no depmap replacement done."


### PR DESCRIPTION
Reduce exceution time by intersecting the dependencies declared in upstream_downstream_depmap with the dependencies listed in requirements.yml