### PR TITLE
AMWSUP-17 EAP Ansible Hub documentation link broken

### DIFF
--- a/playbooks/eap.yml
+++ b/playbooks/eap.yml
@@ -29,8 +29,19 @@
       - roles/wildfly_subs
     downstream_placeholder_delete:
       - build_status
+      - roles_paths
     # anything inside <!--start {{ <downstream_placeholder>_content }} --> and <!--end {{ <downstream_placeholder>_content }} --> will be replaced with content
     downstream_placeholder_content:
+      - placeholder: roles_paths
+        content: |
+          ### Roles
+
+          * [eap_install](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/eap/content/role/eap_install/): download and install
+          * [eap_systemd](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/eap/content/role/eap_systemd/): configure systemd unit
+          * [eap_driver](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/eap/content/role/eap_driver/): install additional driver modules (ie. JDBC)
+          * [eap_utils](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/eap/content/role/eap_utils/): utilities related to EAP
+          * [eap_validation](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/eap/content/role/eap_validation/): validate deployed installation
+          * [eap_uninstall](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/eap/content/role/eap_uninstall/): restore status pre wildfly_install
       - placeholder: galaxy_download
         content: |
           ### Installing the Collection from Automation Hub

--- a/playbooks/jws.yml
+++ b/playbooks/jws.yml
@@ -15,8 +15,18 @@
     # anything inside <!--start {{ <downstream_placeholder>_delete }} --> and <!--end {{ <downstream_placeholder>_delete }} --> will be removed
     downstream_placeholder_delete:
       - build_status
+      - role_content
     # anything inside <!--start {{ <downstream_placeholder>_content }} --> and <!--end {{ <downstream_placeholder>_content }} --> will be replaced with content
     downstream_placeholder_content:
+      - placeholder: role_content
+        content: |
+          - The [jws](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/jws/content/role/jws/) role contains the Ansible playbook and handles the following automated tasks:
+              - Ensures that a Java Development Kit (JDK) is installed on your target hosts
+              - Installs the basic packages that a JBoss Web Server installation requires
+              - Creates a JBoss Web Server user account and group
+              - Installs JBoss Web Server from product archive files or RPM packages
+              - Assigns ownership of the JBoss Web Server directories to the appropriate user account and group
+              - Deploys the `server.xml`, `web.xml`, and `context.xml` files
       - placeholder: ansible_version
         content: |
           Red Hat has tested this collection against Ansible versions 2.14.0 or later.

--- a/playbooks/sso.yml
+++ b/playbooks/sso.yml
@@ -58,8 +58,16 @@
     # anything inside <!--start {{ <downstream_placeholder>_delete }} --> and <!--end {{ <downstream_placeholder>_delete }} --> will be removed
     downstream_placeholder_delete:
       - build_status
+      - roles_paths
     # anything inside <!--start {{ <downstream_placeholder>_content }} --> and <!--end {{ <downstream_placeholder>_content }} --> will be replaced with content
     downstream_placeholder_content:
+      - placeholder: roles_paths
+        content: |
+          ### Included roles
+
+          * [`keycloak`](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/sso/content/role/sso/): role for installing the service.
+          * [`keycloak_realm`](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/sso/content/role/sso_realm/): role for configuring a realm, user federation(s), clients and users, in an installed service.
+          * [`keycloak_quarkus`](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/sso/content/role/sso_quarkus/): role for installing the quarkus variant of keycloak (>= 17.0.0).
       - placeholder: ansible_version
         content: |
           Red Hat has tested this collection against Ansible versions 2.13.0 or later.


### PR DESCRIPTION
Issue: Issue: https://issues.redhat.com/browse/AMWSUP-17

wildfly PR: https://github.com/ansible-middleware/wildfly/pull/161
jws PR: https://github.com/ansible-middleware/jws/pull/258
keycloak PR: https://github.com/ansible-middleware/keycloak/pull/127

There are a few more changes that need to be made! DO NOT MERGE