### PR TITLE
AMW-491 In migration role default value of eap_migration_path_to_env_properties does not exists

### DIFF
--- a/playbooks/eap.yml
+++ b/playbooks/eap.yml
@@ -59,7 +59,9 @@
        replace: "eap_apply_cp: false"
        file: "defaults/main.yml$"
      - match: "32.0.0.Beta1"
-       replace: "8.0.0" 
+       replace: "8.0.0"
+     - match: "37.0.0.Final"
+       replace: "8.0.0"
     galaxy:
       documentation: https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform
       homepage: https://access.redhat.com/products/red-hat-jboss-enterprise-application-platform


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/AMW-491