### PR TITLE
Fix AMQ Broker support section in conversion

### DIFF
--- a/playbooks/amq_broker.yml
+++ b/playbooks/amq_broker.yml
@@ -58,8 +58,7 @@
         content: |
           ## Support
 
-          redhat.amq_broker collection v{{ galaxy_version | default('0.0.0-dev') }} is released as the [Red Hat Ansible certified content collection for JBoss Web Server](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/jws) with [Production Support](https://access.redhat.com/support/offerings/production).
-          If you have any issues or questions related to this collection, please contact support at [Red Hat Customer Experience & Engagement](https://access.redhat.com/support/).
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
       - placeholder: rhn_credentials
         content: |
           #### Downloading from the Customer Portal


### PR DESCRIPTION
## Changes

Use standardized Red Hat Certified Content support text that matches the official template and other collections (like EAP).

- Replace custom support text with template-compliant version
- Aligns with Red Hat Ansible Certified Collections README template
- Matches support section used by other middleware collections

## Related: [AMW-526](https://redhat.atlassian.net/browse/AMW-526)