### PR TITLE
Fix support sections to use standard template

### DIFF
--- a/playbooks/amq_broker.yml
+++ b/playbooks/amq_broker.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
+- name: FQCN migration process
+  ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
   vars:
     upstream_name: activemq
     downstream_name: amq_broker
@@ -58,8 +59,9 @@
         content: |
           ## Support
 
-          redhat.amq_broker collection v{{ galaxy_version | default('0.0.0-dev') }} is released as the [Red Hat Ansible certified content collection for JBoss Web Server](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/jws) with [Production Support](https://access.redhat.com/support/offerings/production).
-          If you have any issues or questions related to this collection, please contact support at [Red Hat Customer Experience & Engagement](https://access.redhat.com/support/).
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
+
+          If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
       - placeholder: rhn_credentials
         content: |
           #### Downloading from the Customer Portal

--- a/playbooks/amq_streams.yml
+++ b/playbooks/amq_streams.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
+- name: FQCN migration process
+  ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
   vars:
     upstream_name: amq_streams
     downstream_name: amq_streams
@@ -35,9 +36,9 @@
         content: |
           ## Support
 
-          redhat.amq_streams collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
-          If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on
-          <https://github.com/ansible-middleware/amq_streams/issues>
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
+
+          If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
       - placeholder: rhn_credentials
         content: |
           #### Downloading from the Customer Portal

--- a/playbooks/data_grid.yml
+++ b/playbooks/data_grid.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
+- name: FQCN migration process
+  ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
   vars:
     upstream_name: infinispan
     downstream_name: data_grid
@@ -72,9 +73,9 @@
         content: |
           ## Support
 
-          redhat.data_grid collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
-          If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on
-          <https://github.com/ansible-middleware/infinispan/issues>
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
+
+          If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
       - placeholder: rhn_credentials
         content: |
           #### Downloading from the Customer Portal

--- a/playbooks/eap.yml
+++ b/playbooks/eap.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
+- name: FQCN migration process
+  ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
   vars:
     upstream_name: wildfly
     downstream_name: eap
@@ -120,7 +121,9 @@
         content: |
           ## Support
 
-          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
+
+          If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
       - placeholder: rhn_credentials
         content: |
           ## Downloading products from the Customer Portal

--- a/playbooks/eap8.yml
+++ b/playbooks/eap8.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
+- name: FQCN migration process
+  ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
   vars:
     upstream_name: wildfly
     downstream_name: eap
@@ -88,9 +89,9 @@
         content: |
           ## Support
 
-          redhat.eap collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
-          If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on
-          <https://github.com/ansible-middleware/wildfly/issues>
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
+
+          If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
       - placeholder: rhn_credentials
         content: |
           ## Downloading products from the Customer Portal

--- a/playbooks/jbcs.yml
+++ b/playbooks/jbcs.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
+- name: FQCN migration process
+  ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
   vars:
     upstream_name: jbcs
     downstream_name: jbcs
@@ -39,9 +40,9 @@
         content: |
           ## Support
 
-          redhat.jbcs collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
-          If you have any issues or questions related to this collection, please contact support at [Red Hat Customer
-          Experience & Engagement](https://access.redhat.com/support/).
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
+
+          If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
 
       - placeholder: rhn_credentials
         content: |

--- a/playbooks/jws.yml
+++ b/playbooks/jws.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
+- name: FQCN migration process
+  ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
   vars:
     upstream_name: jws
     downstream_name: jws

--- a/playbooks/quarkus.yml
+++ b/playbooks/quarkus.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
+- name: FQCN migration process
+  ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
   vars:
     upstream_name: quarkus
     downstream_name: quarkus

--- a/playbooks/rhbk.yml
+++ b/playbooks/rhbk.yml
@@ -28,13 +28,14 @@
     # anything inside <!--start {{ <downstream_placeholder>_content }} --> and <!--end {{ <downstream_placeholder>_content }} --> will be replaced with content
     downstream_placeholder_content: []
   pre_tasks:
-    - name: "Git clone {{ project_git_url }} into {{ lookup('env', 'PWD') }}/upstream/keycloak.git"
+    - name: "Git clone into upstream/keycloak.git from {{ project_git_url }}"
       ansible.builtin.include_role:
         name: community.fqcn_migration.git
         tasks_from: clone.yml
 
   tasks:
-    - ansible.builtin.include_role:
+    - name: Run FQCN migration
+      ansible.builtin.include_role:
         name: community.fqcn_migration.fqcn_migration
       tags: always
 
@@ -107,9 +108,9 @@
         content: |
           ## Support
 
-          redhat.rhbk collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
-          If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on
-          <https://github.com/ansible-middleware/keycloak/issues> referring to the keycloak_quarkus role
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
+
+          If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
       - placeholder: rhn_credentials
         content: |
           #### Downloading from the Customer Portal
@@ -185,7 +186,8 @@
         content: |
           Create realms and clients in [Red Hat Build of Keycloak](https://access.redhat.com/products/red-hat-build-of-keycloak).
   tasks:
-    - ansible.builtin.include_role:
+    - name: Run FQCN migration
+      ansible.builtin.include_role:
         name: community.fqcn_migration.fqcn_migration
       tags: always
 
@@ -197,7 +199,17 @@
       when:
         - release_version is defined and release_version != ""
 
+    - name: "Read galaxy.yml to get collection version"
+      ansible.builtin.slurp:
+        src: "{{ downstream_project }}/galaxy.yml"
+      register: _galaxy_yml
+
+    - name: "Parse collection version from galaxy.yml"
+      ansible.builtin.set_fact:
+        _collection_version: "{{ (_galaxy_yml.content | b64decode | from_yaml).version }}"
+
     - name: "Build collection for {{ downstream_name }}"
       ansible.builtin.command: ansible-galaxy collection build .
       args:
         chdir: "{{ downstream_project }}"
+        creates: "{{ downstream_namespace }}-{{ downstream_name }}-{{ _collection_version }}.tar.gz"

--- a/playbooks/runtimes_common.yml
+++ b/playbooks/runtimes_common.yml
@@ -1,5 +1,6 @@
 ---
-- ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
+- name: FQCN migration process
+  ansible.builtin.import_playbook: community.fqcn_migration.fqcn_migration
   vars:
     upstream_name: common
     downstream_name: runtimes_common
@@ -42,6 +43,6 @@
         content: |
           ## Support
 
-          redhat.runtimes_common collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
-          If you have any issues or questions related to this collection, please contact support at [Red Hat Customer
-          Experience & Engagement](https://access.redhat.com/support/).
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
+
+          If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).

--- a/playbooks/sso.yml
+++ b/playbooks/sso.yml
@@ -291,9 +291,9 @@
         content: |
           ## Support
 
-          redhat.sso collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
-          If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on
-          <https://github.com/ansible-middleware/keycloak/issues>
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
+
+          If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
       - placeholder: rhn_credentials
         content: |
           ## Downloading from the Customer Portal
@@ -394,6 +394,7 @@
       args:
         chdir: "{{ downstream_project }}"
       when: sso_downstream_git.stat.exists | default(false)
+      changed_when: true
 
   post_tasks:
     - name: "Perform release (if requested): {{ release_version == '' | ternary('no release version provided', release_version) }}."
@@ -405,7 +406,17 @@
         - release_version != ""
         - release_version != "TEST"
 
+    - name: "Read galaxy.yml to get collection version"
+      ansible.builtin.slurp:
+        src: "{{ downstream_project }}/galaxy.yml"
+      register: _galaxy_yml
+
+    - name: "Parse collection version from galaxy.yml"
+      ansible.builtin.set_fact:
+        _collection_version: "{{ (_galaxy_yml.content | b64decode | from_yaml).version }}"
+
     - name: Build collection for {{ downstream_name }}
       ansible.builtin.command: ansible-galaxy collection build .
       args:
         chdir: "{{ downstream_project }}"
+        creates: "{{ downstream_namespace }}-{{ downstream_name }}-{{ _collection_version }}.tar.gz"


### PR DESCRIPTION
Updates support placeholder sections in 9 collection playbooks to use the standard Red Hat Ansible Certified Content support template.

Collections updated:
- amq_broker
- amq_streams
- data_grid
- eap
- eap8
- jbcs
- rhbk
- runtimes_common
- sso

Replaces Technical Preview text and bare URLs with the standard support message.

[AMW-522](https://redhat.atlassian.net/browse/AMW-522)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated support guidance to reference Ansible Automation Platform "Create issue" flow and Ansible Forum as a fallback.

* **Refactor**
  * Added human-readable names to FQCN migration import tasks across playbooks for clarity.
  * Extended build workflow to read downstream collection versions and skip rebuilding when artifacts already exist.

* **Bug Fixes**
  * Ensured renamed template files are reported/staged as changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->