### PR TITLE
AMW-561 Data-grid latest version doesn't support vector-search

### DIFF
--- a/playbooks/data_grid.yml
+++ b/playbooks/data_grid.yml
@@ -10,6 +10,8 @@
     gitdescribe_galaxy_version: "{{ true if lookup('env', 'RELEASE_NAME') == '' else false }}"
     upstream_downstream_collections_map:
       - { upstream_name: 'middleware_automation.common', downstream_name: 'redhat.runtimes_common' }
+    excluded_paths_from_downstream:
+      - molecule/vector-search
     post_processors_replacements:
       - match: "data_grid[.]service[.]j2"
         replace: "infinispan.service.j2"


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/AMW-561

The latest data_grid doesn't support vector-search. So removing the particular molecule test from the downstream collection as of now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system configuration to exclude specific content paths from downstream generation workflows, improving operational efficiency and system performance. This configuration adjustment provides finer control over content processing and distribution, preventing unnecessary regeneration of designated resources in downstream operations and workflows. The optimization enhances overall platform performance and streamlines resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->