### PR TITLE
Fix downstream README support section issues across all collections

### DIFF
--- a/playbooks/amq_broker.yml
+++ b/playbooks/amq_broker.yml
@@ -56,9 +56,7 @@
               ansible-galaxy collection install redhat.amq_broker
       - placeholder: support
         content: |
-          ## Support
-
-          redhat.amq_broker collection v{{ galaxy_version | default('0.0.0-dev') }} is released as the [Red Hat Ansible certified content collection for JBoss Web Server](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/jws) with [Production Support](https://access.redhat.com/support/offerings/production).
+          redhat.amq_broker collection v{{ galaxy_version | default('0.0.0-dev') }} is released as the [Red Hat Ansible certified content collection for AMQ Broker](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/amq_broker) with [Production Support](https://access.redhat.com/support/offerings/production).
           If you have any issues or questions related to this collection, please contact support at [Red Hat Customer Experience & Engagement](https://access.redhat.com/support/).
       - placeholder: rhn_credentials
         content: |

--- a/playbooks/amq_streams.yml
+++ b/playbooks/amq_streams.yml
@@ -33,8 +33,6 @@
               ansible-galaxy collection install redhat.amq_streams
       - placeholder: support
         content: |
-          ## Support
-
           redhat.amq_streams collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
           If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on
           <https://github.com/ansible-middleware/amq_streams/issues>

--- a/playbooks/data_grid.yml
+++ b/playbooks/data_grid.yml
@@ -70,8 +70,6 @@
           [Red Hat JBoss EAP](https://www.redhat.com/en/technologies/jboss-middleware/application-platform).
       - placeholder: support
         content: |
-          ## Support
-
           redhat.data_grid collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
           If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on
           <https://github.com/ansible-middleware/infinispan/issues>

--- a/playbooks/eap.yml
+++ b/playbooks/eap.yml
@@ -118,9 +118,7 @@
               ansible-galaxy collection install redhat.eap
       - placeholder: support
         content: |
-          ## Support
-
-          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
+          As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from [Galaxy](https://galaxy.ansible.com/ui/) or [GitHub](https://github.com/ansible-middleware/wildfly/), there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
       - placeholder: rhn_credentials
         content: |
           ## Downloading products from the Customer Portal

--- a/playbooks/eap8.yml
+++ b/playbooks/eap8.yml
@@ -86,8 +86,6 @@
               ansible-galaxy collection install redhat.eap
       - placeholder: support
         content: |
-          ## Support
-
           redhat.eap collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
           If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on
           <https://github.com/ansible-middleware/wildfly/issues>

--- a/playbooks/jbcs.yml
+++ b/playbooks/jbcs.yml
@@ -37,8 +37,6 @@
               $ ansible-galaxy collection install redhat.jbcs
       - placeholder: support
         content: |
-          ## Support
-
           redhat.jbcs collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
           If you have any issues or questions related to this collection, please contact support at [Red Hat Customer
           Experience & Engagement](https://access.redhat.com/support/).

--- a/playbooks/quarkus.yml
+++ b/playbooks/quarkus.yml
@@ -12,3 +12,20 @@
 
     upstream_downstream_collections_map:
       - { upstream_name: 'middleware_automation.common', downstream_name: 'redhat.runtimes_common' }
+    galaxy:
+      documentation: https://ansible-middleware.github.io/quarkus
+      homepage: https://github.com/ansible-middleware/quarkus
+    downstream_placeholder_delete:
+      - build_status
+    downstream_placeholder_content:
+      - placeholder: galaxy_download
+        content: |
+          ### Installing the Collection from Automation Hub
+
+          Before using the collection, you need to setup Ansible Automation Hub as galaxy server; then install it via the CLI:
+
+              ansible-galaxy collection install redhat.quarkus
+      - placeholder: support
+        content: |
+          redhat.quarkus collection v{{ galaxy_version | default('0.0.0-dev') }} is released as the [Red Hat Ansible certified content collection for Quarkus](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/quarkus) with [Production Support](https://access.redhat.com/support/offerings/production).
+          If you have any issues or questions related to this collection, please contact support at [Red Hat Customer Experience & Engagement](https://access.redhat.com/support/).

--- a/playbooks/rhbk.yml
+++ b/playbooks/rhbk.yml
@@ -118,8 +118,6 @@
           * [`rhbk_realm`](https://console.redhat.com/ansible/automation-hub/repo/published/redhat/rhbk/content/role/rhbk_realm/): role for configuring a realm, user federation(s), clients and users, in an installed service.
       - placeholder: support
         content: |
-          ## Support
-
           redhat.rhbk collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
           If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on
           <https://github.com/ansible-middleware/keycloak/issues> referring to the keycloak_quarkus role

--- a/playbooks/runtimes_common.yml
+++ b/playbooks/runtimes_common.yml
@@ -40,8 +40,6 @@
               ansible-galaxy collection install redhat.runtimes_common
       - placeholder: support
         content: |
-          ## Support
-
           redhat.runtimes_common collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
           If you have any issues or questions related to this collection, please contact support at [Red Hat Customer
           Experience & Engagement](https://access.redhat.com/support/).

--- a/playbooks/sso.yml
+++ b/playbooks/sso.yml
@@ -290,8 +290,6 @@
               ansible-galaxy collection install redhat.sso
       - placeholder: support
         content: |
-          ## Support
-
           redhat.sso collection v{{ galaxy_version | default('0.0.0-dev') }} is for [Technical Preview](https://access.redhat.com/support/offerings/techpreview).
           If you have any issues or questions related to collection, please don't hesitate to contact us on <Ansible-middleware-core@redhat.com> or open an issue on
           <https://github.com/ansible-middleware/keycloak/issues>


### PR DESCRIPTION
## Summary

Fixes downstream README support section issues identified during Automation Hub certification reviews.

### Duplicate `## Support` heading (all 9 collection playbooks)

Upstream READMEs have `## Support` outside the `<!--start support -->` markers. When Janus replaces the marker content, placeholder text that also included `## Support` produced duplicate headings in downstream tarballs.

**Fix:** Removed `## Support` from all placeholder content blocks. The heading now comes exclusively from upstream (outside the markers).

### EAP typo and missing links (`eap.yml`)

- Fixed typo: "there may community help" → "there may **be** community help"
- Added `[Galaxy]` and `[GitHub]` markdown links (were plain text)

### AMQ Broker copy-paste error (`amq_broker.yml`)

Support text incorrectly referenced "JBoss Web Server" and linked to the JWS Automation Hub page. Fixed to reference "AMQ Broker" with the correct link.

### Quarkus missing downstream config (`quarkus.yml`)

Added `downstream_placeholder_content` for `support` and `galaxy_download`, plus `galaxy` metadata and `downstream_placeholder_delete` for `build_status`. Previously the downstream tarball kept upstream text verbatim.

## Companion PRs

These set the `license` key in galaxy.yml for each upstream collection:

- https://github.com/ansible-middleware/wildfly/pull/379
- https://github.com/ansible-middleware/quarkus/pull/27
- https://github.com/ansible-middleware/common/pull/45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated support and contact information across multiple Red Hat Ansible collections
  * Added Technical Preview statements with updated contact guidance and GitHub issue links
  * Added Quarkus collection with Galaxy metadata, documentation, and support information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->