### PR TITLE
AMW-562 Removing hardcoded GIT_REPOSITORY_URL from janus

### DIFF
--- a/playbooks/jbcs.yml
+++ b/playbooks/jbcs.yml
@@ -6,7 +6,7 @@
     downstream_name: jbcs
     downstream_namespace: 'redhat'
     upstream_namespace: 'middleware_automation'
-    project_git_url: "https://github.com/ansible-middleware/{{ upstream_name }}.git"
+    project_git_url: "{{ lookup('env', 'GIT_REPOSITORY_URL') | default('https://github.com/ansible-middleware/jbcs.git', true) }}"
     project_git_version: "{{ lookup('env', 'GIT_REPOSITORY_BRANCH') | default('main', true) }}"
     gitdescribe_galaxy_version: "{{ true if lookup('env', 'RELEASE_NAME') == '' else false }}"
     upstream_downstream_collections_map:

--- a/playbooks/runtimes_common.yml
+++ b/playbooks/runtimes_common.yml
@@ -6,7 +6,7 @@
     downstream_name: runtimes_common
     downstream_namespace: 'redhat'
     upstream_namespace: 'middleware_automation'
-    project_git_url: "https://github.com/ansible-middleware/{{ upstream_name }}.git"
+    project_git_url: "{{ lookup('env', 'GIT_REPOSITORY_URL') | default('https://github.com/ansible-middleware/common.git', true) }}"
     project_git_version: "{{ lookup('env', 'GIT_REPOSITORY_BRANCH') | default('main', true) }}"
     gitdescribe_galaxy_version: "{{ true if lookup('env', 'RELEASE_NAME') == '' else false }}"
     upstream_downstream_collections_map:

--- a/playbooks/sso.yml
+++ b/playbooks/sso.yml
@@ -131,7 +131,7 @@
     pandoc_binary: /usr/local/bin/pandoc
     downstream_namespace: 'redhat'
     upstream_namespace: 'middleware_automation'
-    project_git_url: "https://github.com/ansible-middleware/{{ upstream_name }}.git"
+    project_git_url: "{{ lookup('env', 'GIT_REPOSITORY_URL') | default('https://github.com/ansible-middleware/keycloak.git', true) }}"
     project_git_version: "{{ lookup('env', 'GIT_REPOSITORY_BRANCH') | default('main', true) }}"
     gitdescribe_galaxy_version: "{{ true if lookup('env', 'RELEASE_NAME') == '' else false }}"
     upstream_downstream_collections_map:


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/AMW-562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration playbooks now support overriding Git repository URLs via environment variable, with fallback to default repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->