### PR TITLE
Removing keycloak plugins from downstream SSO and RHBK

### DIFF
--- a/playbooks/rhbk.yml
+++ b/playbooks/rhbk.yml
@@ -220,6 +220,17 @@
         replace: 'version: "{{ override_galaxy_version }}"'
       when: override_galaxy_version | length > 0
 
+    # Remove plugins and molecule/keycloak_modules from downstream RHBK (not needed for product)
+    - name: Remove plugins directory from downstream RHBK
+      ansible.builtin.file:
+        path: "{{ downstream_project }}/plugins"
+        state: absent
+
+    - name: Remove molecule/keycloak_modules from downstream RHBK
+      ansible.builtin.file:
+        path: "{{ downstream_project }}/molecule/keycloak_modules"
+        state: absent
+
   post_tasks:
     - name: "Perform release (if requested): {{ release_version == '' | ternary('no release version provided', release_version) }}."
       ansible.builtin.include_role:

--- a/playbooks/sso.yml
+++ b/playbooks/sso.yml
@@ -402,6 +402,17 @@
       when: sso_downstream_git.stat.exists | default(false)
       changed_when: true
 
+    # Remove plugins and molecule/keycloak_modules from downstream SSO (not needed for product)
+    - name: Remove plugins directory from downstream SSO
+      ansible.builtin.file:
+        path: "{{ downstream_project }}/plugins"
+        state: absent
+
+    - name: Remove molecule/keycloak_modules from downstream SSO
+      ansible.builtin.file:
+        path: "{{ downstream_project }}/molecule/keycloak_modules"
+        state: absent
+
     - name: Set downstream galaxy.yml version from RELEASE_NAME
       ansible.builtin.replace:
         path: "{{ downstream_project }}/galaxy.yml"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleaned up downstream collection contents during the migration process by removing leftover plugin and test-module directories before packaging.
  * This helps ensure generated release artifacts include only the intended files and avoid shipping obsolete content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->